### PR TITLE
includesInPatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,17 @@ Although the main motivation behind this GitHub Action is to bridge the gap desc
 
 Every rule can be written in JSON with the following key-value pairs:
 
-| Key             |          Type          | Required | Description                                                                                                                                                                               |
-| --------------- | :--------------------: | :------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`          |        `string`        |    No    | Friendly name to recognize the rule; defaults to the rule filename                                                                                                                        |
-| `action`        |        `string`        |   Yes    | Currently, supported actions are `comment` `review` and `assign`                                                                                                                          |
-| `users`         |       `string[]`       |    No    | GitHub user handles (or emails) on which the rule will take action                                                                                                                        |
-| `teams`         |       `string[]`       |    No    | GitHub teams on which the rule will take action                                                                                                                                           |
-| `includes`      | `string` \| `string[]` |    No    | Glob pattern/s used to match changed filenames in the pull request                                                                                                                        |
-| `excludes`      | `string` \| `string[]` |    No    | Glob pattern/s used to exclude changed filenames (requires `includes` key to be provided)                                                                                                 |
-| `eventJsonPath` |        `string`        |    No    | [JsonPath expression](https://goessner.net/articles/JsonPath/) used to filter information in the [pull request event](https://developer.github.com/webhooks/event-payloads/#pull_request) |
-| `customMessage` |        `string`        |    No    | Message to be commented on the pull request when the rule is applied (requires `action === comment`)                                                                                      |
+| Key               |          Type          | Required | Description                                                                                                                                                                               |
+| ----------------- | :--------------------: | :------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`            |        `string`        |    No    | Friendly name to recognize the rule; defaults to the rule filename                                                                                                                        |
+| `action`          |        `string`        |   Yes    | Currently, supported actions are `comment` `review` and `assign`                                                                                                                          |
+| `users`           |       `string[]`       |    No    | GitHub user handles (or emails) on which the rule will take action                                                                                                                        |
+| `teams`           |       `string[]`       |    No    | GitHub teams on which the rule will take action                                                                                                                                           |
+| `includes`        | `string` \| `string[]` |    No    | Glob pattern/s used to match changed filenames in the pull request                                                                                                                        |
+| `excludes`        | `string` \| `string[]` |    No    | Glob pattern/s used to exclude changed filenames (requires `includes` key to be provided)                                                                                                 |
+| `eventJsonPath`   |        `string`        |    No    | [JsonPath expression](https://goessner.net/articles/JsonPath/) used to filter information in the [pull request event](https://developer.github.com/webhooks/event-payloads/#pull_request) |
+| `includesInPatch` | `string` \| `string[]` |    No    | regex to match content changes (if the regex is malformed or invalid, it will be ignored)                                                                                                 |
+| `customMessage`   |        `string`        |    No    | Message to be commented on the pull request when the rule is applied (requires `action === comment`)                                                                                      |
 
 ## Rule Examples
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Every rule can be written in JSON with the following key-value pairs:
 | `includes`        | `string` \| `string[]` |    No    | Glob pattern/s used to match changed filenames in the pull request                                                                                                                        |
 | `excludes`        | `string` \| `string[]` |    No    | Glob pattern/s used to exclude changed filenames (requires `includes` key to be provided)                                                                                                 |
 | `eventJsonPath`   |        `string`        |    No    | [JsonPath expression](https://goessner.net/articles/JsonPath/) used to filter information in the [pull request event](https://developer.github.com/webhooks/event-payloads/#pull_request) |
-| `includesInPatch` | `string` \| `string[]` |    No    | regex to match content changes (if the regex is malformed or invalid, it will be ignored)                                                                                                 |
+| `includesInPatch` | `string` \| `string[]` |    No    | regex to match file content changes (ignored if malformed or invalid)                                                                                                 |
 | `customMessage`   |        `string`        |    No    | Message to be commented on the pull request when the rule is applied (requires `action === comment`)                                                                                      |
 
 ## Rule Examples

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -102,6 +102,7 @@ describe('use-herald-action', () => {
                 "includes": Array [
                   "*.ts",
                 ],
+                "includesInPatch": Array [],
                 "matches": Object {
                   "includes": Array [
                     "file1.ts",

--- a/__tests__/rules.spec.ts
+++ b/__tests__/rules.spec.ts
@@ -116,7 +116,8 @@ describe('rules', () => {
             },
           ],
           files,
-          event
+          event,
+          []
         )
       ).toMatchInlineSnapshot('Array []');
     });
@@ -135,7 +136,8 @@ describe('rules', () => {
             },
           ],
           files,
-          event
+          event,
+          []
         )
       ).toMatchInlineSnapshot(`
         Array [
@@ -180,7 +182,8 @@ describe('rules', () => {
             },
           ],
           files,
-          event
+          event,
+          []
         )
       ).toMatchInlineSnapshot(`
         Array [
@@ -224,7 +227,8 @@ describe('rules', () => {
             },
           ],
           files,
-          event
+          event,
+          []
         )
       ).toMatchInlineSnapshot(`
         Array [
@@ -237,6 +241,55 @@ describe('rules', () => {
             "matches": Object {
               "includes": Array [
                 "/some/file.ts",
+              ],
+            },
+            "path": "/some/rule.json",
+            "teams": Array [],
+            "users": Array [
+              "@eeny",
+              "@meeny",
+              "@miny",
+              "@moe",
+            ],
+          },
+        ]
+      `);
+    });
+    it('matching includesInPatch (with more than one pattern)', () => {
+      const files = [{ filename: '/some/file.js' }, { filename: '/some/file.ts' }, { filename: '/some/README.md' }];
+      expect(
+        getMatchingRules(
+          [
+            {
+              ...validRule,
+              includes: undefined,
+              includesInPatch: ['(gag).+', '(sim).+', '/noMatch/', '*'],
+              teams: [],
+              path: '/some/rule.json',
+            },
+          ],
+          files,
+          event,
+          [
+            '@@ -132,7 +132,7 @@ module simon @@ -1000,7 +1000,7 @@ module gago',
+            '@@ -132,7 +132,7 @@ module jon @@ -1000,7 +1000,7 @@ module heart',
+          ]
+        )
+      ).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "action": "comment",
+            "customMessage": "This is a custom message for a rule",
+            "includes": undefined,
+            "includesInPatch": Array [
+              "(gag).+",
+              "(sim).+",
+              "/noMatch/",
+              "*",
+            ],
+            "matches": Object {
+              "includesInPatch": Array [
+                "@@ -132,7 +132,7 @@ module simon @@ -1000,7 +1000,7 @@ module gago",
               ],
             },
             "path": "/some/rule.json",
@@ -264,7 +317,8 @@ describe('rules', () => {
             },
           ],
           files,
-          event
+          event,
+          []
         )
       ).toMatchInlineSnapshot(`
         Array [
@@ -296,7 +350,7 @@ describe('rules', () => {
     });
     it('matching includes (includes as string)', () => {
       const files = [{ filename: '/some/file.js' }, { filename: '/some/file.ts' }];
-      expect(getMatchingRules([{ ...validRule, teams: [], path: '/some/rule.json' }], files, event))
+      expect(getMatchingRules([{ ...validRule, teams: [], path: '/some/rule.json' }], files, event, []))
         .toMatchInlineSnapshot(`
         Array [
           Object {
@@ -338,7 +392,8 @@ describe('rules', () => {
             },
           ],
           files,
-          event
+          event,
+          []
         )
       ).toMatchInlineSnapshot(`
         Array [
@@ -432,6 +487,7 @@ describe('rules', () => {
             "includes": Array [
               "*.ts",
             ],
+            "includesInPatch": Array [],
             "name": "rule1.json",
             "path": "/some/rule1.json",
             "teams": Array [],
@@ -449,6 +505,7 @@ describe('rules', () => {
             "includes": Array [
               "*.ts",
             ],
+            "includesInPatch": Array [],
             "name": "rule2.json",
             "path": "/some/rule2.json",
             "teams": Array [
@@ -463,6 +520,7 @@ describe('rules', () => {
             "includes": Array [
               "*.ts",
             ],
+            "includesInPatch": Array [],
             "name": "rule3.json",
             "path": "/some/rule3.json",
             "teams": Array [
@@ -476,6 +534,7 @@ describe('rules', () => {
             "eventJsonPath": "$.pull_request[?(@.login==\\"gagoar\\")].login",
             "excludes": Array [],
             "includes": Array [],
+            "includesInPatch": Array [],
             "name": "rule4.json",
             "path": "/some/rule4.json",
             "teams": Array [],

--- a/dist/src/rules.d.ts
+++ b/dist/src/rules.d.ts
@@ -1,6 +1,7 @@
 import { Event } from './util/constants';
 import { RestEndpointMethodTypes } from '@octokit/rest';
 declare enum RuleMatchers {
+    includesInPatch = "includesInPatch",
     eventJsonPath = "eventJsonPath",
     includes = "includes"
 }
@@ -17,6 +18,7 @@ export interface Rule {
     action: keyof typeof RuleActions;
     includes?: string[];
     excludes?: string[];
+    includesInPatch?: string[];
     eventJsonPath?: string;
     customMessage?: string;
 }
@@ -25,6 +27,6 @@ export declare const loadRules: (rulesLocation: string) => Rule[];
 export declare type MatchingRule = Rule & {
     matches: Partial<Record<RuleMatchers | 'includeExclude', unknown[]>>;
 };
-export declare const getMatchingRules: (rules: Rule[], files: Partial<File> & Required<Pick<File, 'filename'>>[], event: Event) => MatchingRule[];
+export declare const getMatchingRules: (rules: Rule[], files: Partial<File> & Required<Pick<File, 'filename'>>[], event: Event, patchContent: string[]) => MatchingRule[];
 export declare const composeCommentsForUsers: (matchingRules: MatchingRule[]) => string[];
 export {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,12 +57,7 @@ export const main = async () => {
         },
       } = event;
 
-      const {
-        GITHUB_TOKEN,
-        rulesLocation,
-        base = baseSha,
-        dryRun,
-      } = getParams();
+      const { GITHUB_TOKEN, rulesLocation, base = baseSha, dryRun } = getParams();
 
       debug('params:', { rulesLocation, base, dryRun });
 
@@ -90,14 +85,16 @@ export const main = async () => {
         repo,
       });
 
-      const matchingRules = getMatchingRules(rules, files, event);
+      const matchingRules = getMatchingRules(
+        rules,
+        files,
+        event,
+        files.map(({ patch }) => patch)
+      );
 
       debug('matchingRules:', matchingRules);
 
-      const groupedRulesByAction = groupBy(
-        matchingRules,
-        (rule) => rule.action
-      );
+      const groupedRulesByAction = groupBy(matchingRules, (rule) => rule.action);
 
       if (dryRun !== 'true') {
         debug('not a dry Run');
@@ -111,13 +108,7 @@ export const main = async () => {
             groupNames.map((actionName: ActionName) => {
               const action = actionsMap[RuleActions[actionName]];
 
-              return action(
-                client,
-                owner,
-                repo,
-                prNumber,
-                groupedRulesByAction[RuleActions[actionName]]
-              );
+              return action(client, owner, repo, prNumber, groupedRulesByAction[RuleActions[actionName]]);
             }),
           ]);
         }
@@ -127,9 +118,9 @@ export const main = async () => {
     } else {
       setOutput(OUTPUT_NAME, []);
       throw new Error(
-        `use-herald-action only supports [${Object.values(
-          SUPPORTED_EVENT_TYPES
-        ).join(', ')}] events for now, event found: ${env.GITHUB_EVENT_NAME}`
+        `use-herald-action only supports [${Object.values(SUPPORTED_EVENT_TYPES).join(
+          ', '
+        )}] events for now, event found: ${env.GITHUB_EVENT_NAME}`
       );
     }
   } catch (e) {


### PR DESCRIPTION
includes in patch uses regex to match the content diff (patch) in the PR (patch between base commit and head commit) 

this addresses part of  #38 (we will need one that actually looks at the internals in the files that have been changed to close #38)