### PR TITLE
Adding `errorLevel` to rules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+IMPORTANT: Please do not create a Pull Request without [creating an issue first](https://github.com/gagoar/use-herald-action/issues/new).
+
+<!--- write down the issue related to this  PR-->
+
+**Issue Reference**:
+
+## Description
+
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, tests ran to see how -->
+<!--- your change affects other areas of the code, etc. -->
+
+## Checklist:
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This action allows you to add comments, reviewers and assignees to a pull reques
 - [Examples](#examples)
   - [Basic example](#basic-example)
   - [Using output](#using-output)
+  - [Using error levels](#using-error-levels)
 
 <hr>
 
@@ -68,14 +69,15 @@ Every rule can be written in JSON with the following key-value pairs:
 | Key               |          Type          | Required | Description                                                                                                                                                                               |
 | ----------------- | :--------------------: | :------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`            |        `string`        |    No    | Friendly name to recognize the rule; defaults to the rule filename                                                                                                                        |
-| `action`          |        `string`        |   Yes    | Currently, supported actions are `comment` `review` and `assign`                                                                                                                          |
-| `users`           |       `string[]`       |    No    | GitHub user handles (or emails) on which the rule will take action                                                                                                                        |
-| `teams`           |       `string[]`       |    No    | GitHub teams on which the rule will take action                                                                                                                                           |
+| `action`          |        `string`        |   Yes    | Currently, supported actions are `comment`, `review` and `assign`                                                                                                                         |
 | `includes`        | `string` \| `string[]` |    No    | Glob pattern/s used to match changed filenames in the pull request                                                                                                                        |
 | `excludes`        | `string` \| `string[]` |    No    | Glob pattern/s used to exclude changed filenames (requires `includes` key to be provided)                                                                                                 |
 | `eventJsonPath`   |        `string`        |    No    | [JsonPath expression](https://goessner.net/articles/JsonPath/) used to filter information in the [pull request event](https://developer.github.com/webhooks/event-payloads/#pull_request) |
-| `includesInPatch` | `string` \| `string[]` |    No    | regex to match file content changes (ignored if malformed or invalid)                                                                                                                     |
+| `includesInPatch` | `string` \| `string[]` |    No    | Regex to match file content changes (ignored if malformed or invalid)                                                                                                                     |
 | `customMessage`   |        `string`        |    No    | Message to be commented on the pull request when the rule is applied (requires `action === comment`)                                                                                      |
+| `users`           |       `string[]`       |    No    | GitHub user handles (or emails) on which the rule will take action. It will not be used when `action` is set to `comment` and `customMessage` field is present                            |
+| `teams`           |       `string[]`       |    No    | GitHub teams on which the rule will take action. It will not be used when `action` is set to `comment` and `customMessage` field is present                                               |
+| `errorLevel`      |        `string`        |    No    | Currently, supported error levels are `none`, `error`, by default is set to `none`, you can read more [here](#error-levels)                                                               |
 
 ## Rule Examples
 
@@ -108,6 +110,21 @@ Every rule can be written in JSON with the following key-value pairs:
   "action": "assign",
   "includes": "integration/*.ts",
   "eventJSONPath": "$..[?(@.title.match("QA"))]"
+}
+```
+
+## Error levels
+
+When creating rules, you can use the `errorLevel` to change how `use-herald-action` will report back when the rule has no matches. This could be useful to make sure a rule is always matching. For example, when trying to validate that a pull request template is respected.
+
+**Add friendly message when a PR is opened, but if is not applied, fail the workflow**
+
+```json
+{
+  "action": "comment",
+  "customMessage": "Thanks for opening a pull request, looks like all is good! Please wait till the checks are all green to merge ",
+  "eventJSONPath": "$..[?(@.body.match("Issue Ticket:"))]",
+  "errorLevel": "error"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Every rule can be written in JSON with the following key-value pairs:
 | `includes`        | `string` \| `string[]` |    No    | Glob pattern/s used to match changed filenames in the pull request                                                                                                                        |
 | `excludes`        | `string` \| `string[]` |    No    | Glob pattern/s used to exclude changed filenames (requires `includes` key to be provided)                                                                                                 |
 | `eventJsonPath`   |        `string`        |    No    | [JsonPath expression](https://goessner.net/articles/JsonPath/) used to filter information in the [pull request event](https://developer.github.com/webhooks/event-payloads/#pull_request) |
-| `includesInPatch` | `string` \| `string[]` |    No    | regex to match file content changes (ignored if malformed or invalid)                                                                                                 |
+| `includesInPatch` | `string` \| `string[]` |    No    | regex to match file content changes (ignored if malformed or invalid)                                                                                                                     |
 | `customMessage`   |        `string`        |    No    | Message to be commented on the pull request when the rule is applied (requires `action === comment`)                                                                                      |
 
 ## Rule Examples
@@ -107,7 +107,7 @@ Every rule can be written in JSON with the following key-value pairs:
   "teams": ["@QATeam"],
   "action": "assign",
   "includes": "integration/*.ts",
-  "eventJSONPath": "$[?(@.title =~ /QA/)].title"
+  "eventJSONPath": "$..[?(@.title.match("QA"))]"
 }
 ```
 

--- a/__mocks__/event.json
+++ b/__mocks__/event.json
@@ -33,7 +33,7 @@
       "type": "User",
       "site_admin": false
     },
-    "body": "This is a pretty simple change that we need to pull into master.",
+    "body": "This is a pretty simple change that we need to pull into master (ticket: ).",
     "created_at": "2019-05-15T15:20:33Z",
     "updated_at": "2019-05-15T15:20:33Z",
     "closed_at": null,

--- a/__mocks__/event.json
+++ b/__mocks__/event.json
@@ -33,7 +33,7 @@
       "type": "User",
       "site_admin": false
     },
-    "body": "This is a pretty simple change that we need to pull into master (ticket: ).",
+    "body": "This is a pretty simple change that we need to pull into master (ticket: 123).",
     "created_at": "2019-05-15T15:20:33Z",
     "updated_at": "2019-05-15T15:20:33Z",
     "closed_at": null,

--- a/__mocks__/required_rules/rule1.json
+++ b/__mocks__/required_rules/rule1.json
@@ -1,0 +1,6 @@
+{
+  "customMessage": "This is a custom message for a rule",
+  "users": ["@eeny", "@meeny", "@miny", "@moe"],
+  "action": "comment",
+  "includes": ["*.ts"]
+}

--- a/__mocks__/required_rules/rule2.json
+++ b/__mocks__/required_rules/rule2.json
@@ -1,0 +1,6 @@
+{
+  "customMessage": "Thanks for contributing, everything looks good in your PR description, please give us some time to review.",
+  "action": "comment",
+  "eventJsonPath": "$..[?(@.body.match('Issue: '))]",
+  "errorLevel": "error"
+}

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-var-requires */
 import nock from 'nock';
 import { Props } from '../src';
 import { Event } from '../src/util/constants';
@@ -21,6 +21,7 @@ jest.mock('../src/environment', () => {
   };
 });
 
+type Main = { main: () => Promise<void> };
 const event = require(`../${env.GITHUB_EVENT_PATH}`) as Event;
 
 const handleComment = comment.handleComment as jest.Mock<any>;
@@ -46,7 +47,7 @@ describe('use-herald-action', () => {
       return key === Props.rulesLocation ? undefined : mockedInput[key];
     });
 
-    const { main } = require('../src') as { main: Function };
+    const { main } = require('../src') as { main: () => Promise<void> };
 
     await main();
 
@@ -63,7 +64,7 @@ describe('use-herald-action', () => {
       )
       .reply(200, getCompareCommitsResponse);
 
-    const { main } = require('../src') as { main: Function };
+    const { main } = require('../src') as Main;
 
     await main();
 
@@ -84,7 +85,7 @@ describe('use-herald-action', () => {
       )
       .reply(200, getCompareCommitsResponse);
 
-    const { main } = require('../src') as { main: Function };
+    const { main } = require('../src') as Main;
 
     await main();
 
@@ -143,7 +144,7 @@ describe('use-herald-action', () => {
       )
       .reply(200, getCompareCommitsResponse);
 
-    const { main } = require('../src') as { main: Function };
+    const { main } = require('../src') as Main;
 
     await main();
 

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -47,7 +47,7 @@ describe('use-herald-action', () => {
       return key === Props.rulesLocation ? undefined : mockedInput[key];
     });
 
-    const { main } = require('../src') as { main: () => Promise<void> };
+    const { main } = require('../src') as Main;
 
     await main();
 

--- a/__tests__/rules.spec.ts
+++ b/__tests__/rules.spec.ts
@@ -515,6 +515,7 @@ describe('rules', () => {
         },
         '/some/badRule.json': {
           ...validRule,
+          customMessage: undefined,
           teams: undefined,
           users: undefined,
         },
@@ -595,11 +596,4 @@ describe('rules', () => {
       `);
     });
   });
-
-  // it.only('trying the jsonPath pattern', () => {
-  //   const pattern = '$[?(@.title.contains("README")].title';
-  //   const response = JSONPath.query(eventJSON, pattern);
-  //   debugger;
-  //   expect(response).toMatchInlineSnapshot();
-  // })
 });

--- a/__tests__/rules.spec.ts
+++ b/__tests__/rules.spec.ts
@@ -122,6 +122,52 @@ describe('rules', () => {
       ).toMatchInlineSnapshot('Array []');
     });
 
+    it('Matches includes and eventJsonPath (using contains)', () => {
+      const files = [{ filename: '/some/file.js' }, { filename: '/some/file.ts' }];
+
+      expect(
+        getMatchingRules(
+          [
+            {
+              ...validRule,
+              teams: [],
+              eventJsonPath: '$..[?(@.title.match("README"))].title',
+              path: '/some/rule.json',
+            },
+          ],
+          files,
+          event,
+          []
+        )
+      ).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "action": "comment",
+            "customMessage": "This is a custom message for a rule",
+            "eventJsonPath": "$..[?(@.title.match(\\"README\\"))].title",
+            "includes": Array [
+              "*.ts",
+            ],
+            "matches": Object {
+              "eventJsonPath": Array [
+                "Update the README with new information.",
+              ],
+              "includes": Array [
+                "/some/file.ts",
+              ],
+            },
+            "path": "/some/rule.json",
+            "teams": Array [],
+            "users": Array [
+              "@eeny",
+              "@meeny",
+              "@miny",
+              "@moe",
+            ],
+          },
+        ]
+      `);
+    });
     it('Matches includes and eventJsonPath', () => {
       const files = [{ filename: '/some/file.js' }, { filename: '/some/file.ts' }];
 
@@ -549,4 +595,11 @@ describe('rules', () => {
       `);
     });
   });
+
+  // it.only('trying the jsonPath pattern', () => {
+  //   const pattern = '$[?(@.title.contains("README")].title';
+  //   const response = JSONPath.query(eventJSON, pattern);
+  //   debugger;
+  //   expect(response).toMatchInlineSnapshot();
+  // })
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -4343,7 +4343,6 @@ const isEventSupported = (event) => {
 };
 
 // CONCATENATED MODULE: ./src/index.ts
-/* eslint-disable @typescript-eslint/camelcase */
 
 
 
@@ -7100,7 +7099,7 @@ exports.default = AsyncReader;
 
 Object.defineProperty(exports, '__esModule', { value: true });
 
-const VERSION = "2.2.3";
+const VERSION = "2.2.4";
 
 /**
  * Some “list” response that can be paginated have a different response structure
@@ -8703,7 +8702,7 @@ const Endpoints = {
         previews: ["wyandotte"]
       }
     }],
-    listReposForUser: ["GET /user/{migration_id}/repositories", {
+    listReposForUser: ["GET /user/migrations/{migration_id}/repositories", {
       mediaType: {
         previews: ["wyandotte"]
       }
@@ -9356,7 +9355,7 @@ const Endpoints = {
   }
 };
 
-const VERSION = "4.1.0";
+const VERSION = "4.1.2";
 
 function endpointsToMethods(octokit, endpointsMap) {
   const newMethods = {};
@@ -10376,7 +10375,7 @@ function withDefaults(oldDefaults, newDefaults) {
   });
 }
 
-const VERSION = "6.0.4";
+const VERSION = "6.0.5";
 
 const userAgent = `octokit-endpoint.js/${VERSION} ${universalUserAgent.getUserAgent()}`; // DEFAULTS has all properties set that EndpointOptions has, except url.
 // So we use RequestParameters and add method as additional required property.
@@ -21740,7 +21739,7 @@ var isPlainObject = _interopDefault(__webpack_require__(960));
 var nodeFetch = _interopDefault(__webpack_require__(828));
 var requestError = __webpack_require__(463);
 
-const VERSION = "5.4.6";
+const VERSION = "5.4.7";
 
 function getBufferResponse(response) {
   return response.arrayBuffer();
@@ -30395,7 +30394,7 @@ var pluginRequestLog = __webpack_require__(916);
 var pluginPaginateRest = __webpack_require__(299);
 var pluginRestEndpointMethods = __webpack_require__(352);
 
-const VERSION = "18.0.1";
+const VERSION = "18.0.3";
 
 const Octokit = core.Octokit.plugin(pluginRequestLog.requestLog, pluginRestEndpointMethods.restEndpointMethods, pluginPaginateRest.paginateRest).defaults({
   userAgent: `octokit-rest.js/${VERSION}`

--- a/dist/src/rules.d.ts
+++ b/dist/src/rules.d.ts
@@ -10,6 +10,10 @@ export declare enum RuleActions {
     review = "review",
     assign = "assign"
 }
+declare enum ErrorLevels {
+    none = "none",
+    error = "error"
+}
 export interface Rule {
     name?: string;
     path: string;
@@ -21,12 +25,14 @@ export interface Rule {
     includesInPatch?: string[];
     eventJsonPath?: string;
     customMessage?: string;
+    errorLevel?: keyof typeof ErrorLevels;
 }
 declare type File = RestEndpointMethodTypes['repos']['compareCommits']['response']['data']['files'][0];
 export declare const loadRules: (rulesLocation: string) => Rule[];
 export declare type MatchingRule = Rule & {
     matches: Partial<Record<RuleMatchers | 'includeExclude', unknown[]>>;
 };
+export declare const allRequiredRulesHaveMatched: (rules: Rule[], matchingRules: MatchingRule[]) => boolean;
 export declare const getMatchingRules: (rules: Rule[], files: Partial<File> & Required<Pick<File, 'filename'>>[], event: Event, patchContent: string[]) => MatchingRule[];
 export declare const composeCommentsForUsers: (matchingRules: MatchingRule[]) => string[];
 export {};

--- a/package.json
+++ b/package.json
@@ -108,9 +108,8 @@
     "p-queue": "6.6.0"
   },
   "devDependencies": {
-    "nock": "13.0.3",
-    "@types/lodash.groupby": "4.6.6",
     "@types/jest": "26.0.9",
+    "@types/lodash.groupby": "4.6.6",
     "@types/node": "13.13.15",
     "@typescript-eslint/eslint-plugin": "3.8.0",
     "@typescript-eslint/parser": "3.8.0",
@@ -125,6 +124,7 @@
     "jest-mock-process": "1.4.0",
     "lint-staged": "10.2.11",
     "ncc": "0.3.6",
+    "nock": "13.0.3",
     "prettier": "2.0.5",
     "prettier-eslint": "11.0.0",
     "prettier-eslint-cli": "5.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import { getInput, setOutput, setFailed } from '@actions/core';
 import groupBy from 'lodash.groupby';
 import { handleComment } from './comment';
@@ -40,7 +39,7 @@ const getParams = () => {
   }, {} as Partial<Record<keyof typeof Props, string>>);
 };
 
-export const main = async () => {
+export const main = async (): Promise<void> => {
   try {
     if (isEventSupported(env.GITHUB_EVENT_NAME)) {
       const event = loadJSONFile(env.GITHUB_EVENT_PATH) as Event;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { getInput, setOutput, setFailed } from '@actions/core';
 import groupBy from 'lodash.groupby';
 import { handleComment } from './comment';
-import { loadRules, getMatchingRules, RuleActions } from './rules';
+import { loadRules, getMatchingRules, RuleActions, allRequiredRulesHaveMatched } from './rules';
 import { Event, OUTPUT_NAME, SUPPORTED_EVENT_TYPES } from './util/constants';
 import { logger } from './util/debug';
 import { env } from './environment';
@@ -92,6 +92,14 @@ export const main = async (): Promise<void> => {
       );
 
       debug('matchingRules:', matchingRules);
+
+      if (!allRequiredRulesHaveMatched(rules, matchingRules)) {
+        throw new Error(
+          `Not all Rules with errorLevel set to error have matched. Please double check that these rules apply: ${matchingRules
+            .map((rule) => rule.name)
+            .join(', ')}`
+        );
+      }
 
       const groupedRulesByAction = groupBy(matchingRules, (rule) => rule.action);
 


### PR DESCRIPTION
Adding `errorLevel` will allow rules to fail the workflow if these are not applied. 

It will be handy to create different workflows with really specific intents. The first use case for this is the ability to fail a check when the PR does not have the right template. but it could be expanded to anything that is meant to be used for. 
