### PR TITLE
Simplifying logic for matchers and transforming MatchingRules as a boolean

### DIFF
--- a/__tests__/assignees.spec.ts
+++ b/__tests__/assignees.spec.ts
@@ -15,7 +15,7 @@ describe('handleAssignees', () => {
     path: 'rules/rule.json',
     customMessage: 'Custom message',
     teams: [],
-    matches: { glob: ['fileChanged.ts'] },
+    matched: true,
   };
   beforeEach(() => {
     nock.cleanAll();

--- a/__tests__/comment.spec.ts
+++ b/__tests__/comment.spec.ts
@@ -26,7 +26,7 @@ describe('handleComment', () => {
       path: 'rules/rule.json',
       customMessage: 'Custom message',
       teams: [],
-      matches: { includes: ['fileChanged.ts'] },
+      matched: true,
     };
 
     const github = nock('https://api.github.com')
@@ -91,7 +91,7 @@ describe('handleComment', () => {
       path: 'rules/rule.json',
       customMessage: 'Custom message',
       teams: [],
-      matches: { includes: ['fileChanged.ts'] },
+      matched: true,
     };
 
     nock('https://api.github.com')

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -131,11 +131,7 @@ describe('use-herald-action', () => {
                   "*.ts",
                 ],
                 "includesInPatch": Array [],
-                "matches": Object {
-                  "includes": Array [
-                    "file1.ts",
-                  ],
-                },
+                "matched": true,
                 "name": "rule1.json",
                 "path": "${env.GITHUB_WORKSPACE}/__mocks__/rules/rule1.json",
                 "teams": Array [],

--- a/__tests__/reviewers.spec.ts
+++ b/__tests__/reviewers.spec.ts
@@ -15,7 +15,7 @@ describe('handleReviewers', () => {
     path: 'rules/rule.json',
     customMessage: 'Custom message',
     teams: ['@myTeam'],
-    matches: { glob: ['fileChanged.ts'] },
+    matched: true,
   };
   beforeEach(() => {
     nock.cleanAll();
@@ -25,9 +25,7 @@ describe('handleReviewers', () => {
       .post(`/repos/${owner}/${repo}/pulls/${prIssue}/requested_reviewers`)
       .reply(201, requestedReviewersResponse);
 
-    const response = await handleReviewers(client, owner, repo, prIssue, [
-      rule,
-    ]);
+    const response = await handleReviewers(client, owner, repo, prIssue, [rule]);
 
     expect(response).toMatchInlineSnapshot(`
       Array [

--- a/__tests__/rules.spec.ts
+++ b/__tests__/rules.spec.ts
@@ -413,6 +413,70 @@ describe('rules', () => {
       `);
     });
 
+    it('does not matches eventJsonPath because includes does not match', () => {
+      const files = [{ filename: '/some/file.ts' }];
+
+      expect(
+        getMatchingRules(
+          [
+            {
+              ...validRule,
+              includes: ['*.js'],
+              teams: ['eeny'],
+              eventJsonPath: ['$.pull_request[?(@.login=="gagoar")].login'],
+              path: '/some/rule.json',
+            },
+          ],
+          files,
+          event,
+          []
+        )
+      ).toMatchObject([]);
+    });
+    it('matches includes && eventJsonPath in the same rule', () => {
+      const files = [{ filename: '/some/file.js' }];
+
+      expect(
+        getMatchingRules(
+          [
+            {
+              ...validRule,
+              includes: ['*.js'],
+              teams: ['eeny'],
+              eventJsonPath: ['$.pull_request[?(@.login=="gagoar")].login'],
+              path: '/some/rule.json',
+            },
+          ],
+          files,
+          event,
+          []
+        )
+      ).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "action": "comment",
+            "customMessage": "This is a custom message for a rule",
+            "eventJsonPath": Array [
+              "$.pull_request[?(@.login==\\"gagoar\\")].login",
+            ],
+            "includes": Array [
+              "*.js",
+            ],
+            "matched": true,
+            "path": "/some/rule.json",
+            "teams": Array [
+              "eeny",
+            ],
+            "users": Array [
+              "eeny",
+              "meeny",
+              "miny",
+              "moe",
+            ],
+          },
+        ]
+      `);
+    });
     it('matching eventJsonPath', () => {
       const files = [{ filename: '/some/file.js' }];
 

--- a/__tests__/rules.spec.ts
+++ b/__tests__/rules.spec.ts
@@ -44,7 +44,7 @@ describe('rules', () => {
           {
             ...validRule,
             path: '/some/rule.json',
-            matches: { includes: ['/some/file.ts'] },
+            matched: true,
             teams: [],
           },
         ])
@@ -61,14 +61,14 @@ describe('rules', () => {
             ...validRule,
             customMessage: undefined,
             path: '/some/rule.json',
-            matches: { includes: ['/some/file.ts'] },
+            matched: true,
             teams: [],
           },
           {
             ...validRule,
             customMessage: undefined,
             path: '/some/rule1.json',
-            matches: { includes: ['/some/file.ts'] },
+            matched: true,
             teams: ['@awesomeTeam'],
           },
         ])
@@ -87,7 +87,7 @@ describe('rules', () => {
             ...validRule,
             customMessage: undefined,
             path: '/some/rule.json',
-            matches: { includes: ['/some/file.ts'] },
+            matched: true,
             teams: [],
           },
         ])
@@ -149,35 +149,7 @@ describe('rules', () => {
             "includes": Array [
               "*.ts",
             ],
-            "matches": Object {
-              "eventJsonPath": Array [
-                "<!--- write down the issue related to this  PR-->
-
-        **Issue Reference**:  #66 
-
-        ## Description
-
-        adding rules to validate the PR contains an Issue Reference, so it's always linked. 
-
-        ## Motivation and Context
-
-        This is something that will save time when a PR is opened. 
-
-        ## How Has This Been Tested?
-
-        Creating this PR and editing it. given that it reacts to opened and edited. 
-        some edit
-
-        ## Checklist:
-        - [x] My code follows the code style of this project.
-        - [ ] My change requires a change to the documentation.
-        - [ ] I have updated the documentation accordingly.
-        ",
-              ],
-              "includes": Array [
-                "/some/file.ts",
-              ],
-            },
+            "matched": true,
             "path": "/some/rule.json",
             "teams": Array [],
             "users": Array [
@@ -218,14 +190,7 @@ describe('rules', () => {
             "includes": Array [
               "*.ts",
             ],
-            "matches": Object {
-              "eventJsonPath": Array [
-                "gagoar",
-              ],
-              "includes": Array [
-                "/some/file.ts",
-              ],
-            },
+            "matched": true,
             "path": "/some/rule.json",
             "teams": Array [],
             "users": Array [
@@ -266,11 +231,7 @@ describe('rules', () => {
             "includes": Array [
               "*.ts",
             ],
-            "matches": Object {
-              "includeExclude": Array [
-                "/some/file.ts",
-              ],
-            },
+            "matched": true,
             "path": "/some/rule.json",
             "teams": Array [],
             "users": Array [
@@ -308,11 +269,7 @@ describe('rules', () => {
             "includes": Array [
               "*.ts",
             ],
-            "matches": Object {
-              "includes": Array [
-                "/some/file.ts",
-              ],
-            },
+            "matched": true,
             "path": "/some/rule.json",
             "teams": Array [],
             "users": Array [
@@ -324,6 +281,28 @@ describe('rules', () => {
           },
         ]
       `);
+    });
+    it('does not match includesInPatch (with more than one pattern)', () => {
+      const files = [{ filename: '/some/file.js' }, { filename: '/some/file.ts' }, { filename: '/some/README.md' }];
+      expect(
+        getMatchingRules(
+          [
+            {
+              ...validRule,
+              includes: undefined,
+              includesInPatch: ['/noMatch/'],
+              teams: [],
+              path: '/some/rule.json',
+            },
+          ],
+          files,
+          event,
+          [
+            '@@ -132,7 +132,7 @@ module simon @@ -1000,7 +1000,7 @@ module gago',
+            '@@ -132,7 +132,7 @@ module jon @@ -1000,7 +1000,7 @@ module heart',
+          ]
+        )
+      ).toMatchObject([]);
     });
     it('matching includesInPatch (with more than one pattern)', () => {
       const files = [{ filename: '/some/file.js' }, { filename: '/some/file.ts' }, { filename: '/some/README.md' }];
@@ -357,11 +336,7 @@ describe('rules', () => {
               "/noMatch/",
               "*",
             ],
-            "matches": Object {
-              "includesInPatch": Array [
-                "@@ -132,7 +132,7 @@ module simon @@ -1000,7 +1000,7 @@ module gago",
-              ],
-            },
+            "matched": true,
             "path": "/some/rule.json",
             "teams": Array [],
             "users": Array [
@@ -400,12 +375,7 @@ describe('rules', () => {
               "*.md",
               ".gitignore",
             ],
-            "matches": Object {
-              "includes": Array [
-                "/some/file.ts",
-                "/some/README.md",
-              ],
-            },
+            "matched": true,
             "path": "/some/rule.json",
             "teams": Array [],
             "users": Array [
@@ -429,11 +399,7 @@ describe('rules', () => {
             "includes": Array [
               "*.ts",
             ],
-            "matches": Object {
-              "includes": Array [
-                "/some/file.ts",
-              ],
-            },
+            "matched": true,
             "path": "/some/rule.json",
             "teams": Array [],
             "users": Array [
@@ -474,11 +440,7 @@ describe('rules', () => {
               "$.pull_request[?(@.login==\\"gagoar\\")].login",
             ],
             "includes": undefined,
-            "matches": Object {
-              "eventJsonPath": Array [
-                "gagoar",
-              ],
-            },
+            "matched": true,
             "path": "/some/rule.json",
             "teams": Array [],
             "users": Array [

--- a/dist/index.js
+++ b/dist/index.js
@@ -4266,6 +4266,7 @@ const isMatch = (rule, options) => {
     const matches = keyMatchers
         .filter((matcher) => { var _a; return (_a = rule[matcher]) === null || _a === void 0 ? void 0 : _a.length; })
         .map((matcher) => matchers[matcher](rule, options));
+    debug('isMatch:', { rule, matches });
     return matches.length ? matches.every((match) => match === true) : false;
 };
 const getMatchingRules = (rules, files, event, patchContent) => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1193,7 +1193,7 @@ function onceStrict (fn) {
 /***/ 53:
 /***/ (function(module) {
 
-module.exports = {"_args":[["estraverse@4.3.0","/Users/cyamonide/GitHub/use-herald-action"]],"_from":"estraverse@4.3.0","_id":"estraverse@4.3.0","_inBundle":false,"_integrity":"sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==","_location":"/estraverse","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"estraverse@4.3.0","name":"estraverse","escapedName":"estraverse","rawSpec":"4.3.0","saveSpec":null,"fetchSpec":"4.3.0"},"_requiredBy":["/escodegen","/eslint-scope","/esrecurse","/prettier-eslint-cli/eslint-scope","/prettier-eslint-cli/eslint/eslint-scope","/prettier-eslint-cli/vue-eslint-parser/eslint-scope"],"_resolved":"https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz","_spec":"4.3.0","_where":"/Users/cyamonide/GitHub/use-herald-action","bugs":{"url":"https://github.com/estools/estraverse/issues"},"description":"ECMAScript JS AST traversal functions","devDependencies":{"babel-preset-env":"^1.6.1","babel-register":"^6.3.13","chai":"^2.1.1","espree":"^1.11.0","gulp":"^3.8.10","gulp-bump":"^0.2.2","gulp-filter":"^2.0.0","gulp-git":"^1.0.1","gulp-tag-version":"^1.3.0","jshint":"^2.5.6","mocha":"^2.1.0"},"engines":{"node":">=4.0"},"homepage":"https://github.com/estools/estraverse","license":"BSD-2-Clause","main":"estraverse.js","maintainers":[{"name":"Yusuke Suzuki","email":"utatane.tea@gmail.com","url":"http://github.com/Constellation"}],"name":"estraverse","repository":{"type":"git","url":"git+ssh://git@github.com/estools/estraverse.git"},"scripts":{"lint":"jshint estraverse.js","test":"npm run-script lint && npm run-script unit-test","unit-test":"mocha --compilers js:babel-register"},"version":"4.3.0"};
+module.exports = {"_args":[["estraverse@4.3.0","/Users/gfrigerio/base/use-herald"]],"_from":"estraverse@4.3.0","_id":"estraverse@4.3.0","_inBundle":false,"_integrity":"sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==","_location":"/estraverse","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"estraverse@4.3.0","name":"estraverse","escapedName":"estraverse","rawSpec":"4.3.0","saveSpec":null,"fetchSpec":"4.3.0"},"_requiredBy":["/@typescript-eslint/experimental-utils/eslint-scope","/escodegen","/eslint-scope","/eslint/eslint-scope","/esrecurse","/prettier-eslint-cli/eslint/eslint-scope","/vue-eslint-parser/eslint-scope"],"_resolved":"https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz","_spec":"4.3.0","_where":"/Users/gfrigerio/base/use-herald","bugs":{"url":"https://github.com/estools/estraverse/issues"},"description":"ECMAScript JS AST traversal functions","devDependencies":{"babel-preset-env":"^1.6.1","babel-register":"^6.3.13","chai":"^2.1.1","espree":"^1.11.0","gulp":"^3.8.10","gulp-bump":"^0.2.2","gulp-filter":"^2.0.0","gulp-git":"^1.0.1","gulp-tag-version":"^1.3.0","jshint":"^2.5.6","mocha":"^2.1.0"},"engines":{"node":">=4.0"},"homepage":"https://github.com/estools/estraverse","license":"BSD-2-Clause","main":"estraverse.js","maintainers":[{"name":"Yusuke Suzuki","email":"utatane.tea@gmail.com","url":"http://github.com/Constellation"}],"name":"estraverse","repository":{"type":"git","url":"git+ssh://git@github.com/estools/estraverse.git"},"scripts":{"lint":"jshint estraverse.js","test":"npm run-script lint && npm run-script unit-test","unit-test":"mocha --compilers js:babel-register"},"version":"4.3.0"};
 
 /***/ }),
 
@@ -4194,27 +4194,24 @@ const loadRules = (rulesLocation) => {
 };
 const includeExcludeFiles = ({ includes, excludes, fileNames }) => {
     debug('includeExcludeFiles...');
-    const matches = {};
     let results = [];
     if (includes === null || includes === void 0 ? void 0 : includes.length) {
         results = includes.reduce((memo, include) => {
             const matches = minimatch_default().match(fileNames, include, { matchBase: true });
             return [...memo, ...matches];
         }, []);
-        matches[RuleMatchers.includes] = [...new Set(results)];
+        results = [...new Set(results)];
+        debug('includes matches', { results, includes });
         if ((excludes === null || excludes === void 0 ? void 0 : excludes.length) && results.length) {
             const toExclude = excludes.reduce((memo, exclude) => {
                 const matches = minimatch_default().match(results, exclude, { matchBase: true });
                 return [...memo, ...matches];
             }, []);
             results = results.filter((filename) => !toExclude.includes(filename));
+            debug('excludes matches:', { results, excludes });
         }
-        debug('evaluating includes:', matches);
     }
-    if ((includes === null || includes === void 0 ? void 0 : includes.length) && (excludes === null || excludes === void 0 ? void 0 : excludes.length)) {
-        return { includeExclude: results };
-    }
-    return matches;
+    return !!results.length;
 };
 const handleIncludesInPath = (patterns, patchContent) => {
     debug('handleIncludesInPath...');
@@ -4229,7 +4226,7 @@ const handleIncludesInPath = (patterns, patchContent) => {
             return memo;
         }
     }, []);
-    return [...new Set(matches)];
+    return !![...new Set(matches)].length;
 };
 const allRequiredRulesHaveMatched = (rules, matchingRules) => {
     const requiredRules = rules.filter((rule) => rule.errorLevel && rule.errorLevel === ErrorLevels.error);
@@ -4241,6 +4238,7 @@ const allRequiredRulesHaveMatched = (rules, matchingRules) => {
     return requiredRules.every((rule) => matchingRulesNames.includes(rule.name));
 };
 const handleEventJsonPath = (event, patterns) => {
+    debug('eventJsonPath', patterns);
     let results;
     patterns.find((pattern) => {
         const matches = jsonpath_default().query(event, pattern);
@@ -4249,22 +4247,27 @@ const handleEventJsonPath = (event, patterns) => {
         }
         return matches.length;
     });
-    return results;
+    debug('eventJSONPath matches:', results);
+    return !!results;
 };
 const getMatchingRules = (rules, files, event, patchContent) => {
     const fileNames = files.map(({ filename }) => filename);
     const matchingRules = rules.reduce((memo, rule) => {
         var _a, _b;
-        let matches = {};
         const extraMatches = includeExcludeFiles({
             includes: rule.includes,
             excludes: rule.excludes,
             fileNames,
         });
+        if (extraMatches) {
+            return [...memo, Object.assign(Object.assign({}, rule), { matched: extraMatches })];
+        }
         if ((_a = rule.eventJsonPath) === null || _a === void 0 ? void 0 : _a.length) {
-            debug('eventJsonPath', rule.eventJsonPath, event.pull_request.body);
             try {
-                matches.eventJsonPath = handleEventJsonPath(event, rule.eventJsonPath);
+                const eventJsonPath = handleEventJsonPath(event, rule.eventJsonPath);
+                if (eventJsonPath) {
+                    return [...memo, Object.assign(Object.assign({}, rule), { matched: eventJsonPath })];
+                }
             }
             catch (e) {
                 debug('something went wrong with the query:Error:', e);
@@ -4272,10 +4275,12 @@ const getMatchingRules = (rules, files, event, patchContent) => {
         }
         if ((_b = rule.includesInPatch) === null || _b === void 0 ? void 0 : _b.length) {
             debug('includesInPatch');
-            matches.includesInPatch = handleIncludesInPath(rule.includesInPatch, patchContent);
+            const includesInPatch = handleIncludesInPath(rule.includesInPatch, patchContent);
+            if (includesInPatch) {
+                return [...memo, Object.assign(Object.assign({}, rule), { matched: includesInPatch })];
+            }
         }
-        matches = Object.assign(Object.assign({}, matches), extraMatches);
-        return Object.values(matches).some((value) => value === null || value === void 0 ? void 0 : value.length) ? [...memo, Object.assign(Object.assign({}, rule), { matches })] : memo;
+        return memo;
     }, []);
     return matchingRules;
 };
@@ -4301,7 +4306,6 @@ const composeCommentsForUsers = (matchingRules) => {
 };
 
 // CONCATENATED MODULE: ./src/comment.ts
-/* eslint-disable @typescript-eslint/camelcase */
 
 
 
@@ -4574,7 +4578,7 @@ exports.IS_SUPPORT_READDIR_WITH_FILE_TYPES = IS_MATCHED_BY_MAJOR || IS_MATCHED_B
 /***/ 175:
 /***/ (function(module) {
 
-module.exports = {"_args":[["escodegen@1.14.1","/Users/cyamonide/GitHub/use-herald-action"]],"_from":"escodegen@1.14.1","_id":"escodegen@1.14.1","_inBundle":false,"_integrity":"sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==","_location":"/escodegen","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"escodegen@1.14.1","name":"escodegen","escapedName":"escodegen","rawSpec":"1.14.1","saveSpec":null,"fetchSpec":"1.14.1"},"_requiredBy":["/jsdom","/static-eval"],"_resolved":"https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz","_spec":"1.14.1","_where":"/Users/cyamonide/GitHub/use-herald-action","bin":{"esgenerate":"bin/esgenerate.js","escodegen":"bin/escodegen.js"},"bugs":{"url":"https://github.com/estools/escodegen/issues"},"dependencies":{"esprima":"^4.0.1","estraverse":"^4.2.0","esutils":"^2.0.2","optionator":"^0.8.1","source-map":"~0.6.1"},"description":"ECMAScript code generator","devDependencies":{"acorn":"^7.1.0","bluebird":"^3.4.7","bower-registry-client":"^1.0.0","chai":"^3.5.0","commonjs-everywhere":"^0.9.7","gulp":"^3.8.10","gulp-eslint":"^3.0.1","gulp-mocha":"^3.0.1","semver":"^5.1.0"},"engines":{"node":">=4.0"},"files":["LICENSE.BSD","README.md","bin","escodegen.js","package.json"],"homepage":"http://github.com/estools/escodegen","license":"BSD-2-Clause","main":"escodegen.js","maintainers":[{"name":"Yusuke Suzuki","email":"utatane.tea@gmail.com","url":"http://github.com/Constellation"}],"name":"escodegen","optionalDependencies":{"source-map":"~0.6.1"},"repository":{"type":"git","url":"git+ssh://git@github.com/estools/escodegen.git"},"scripts":{"build":"cjsify -a path: tools/entry-point.js > escodegen.browser.js","build-min":"cjsify -ma path: tools/entry-point.js > escodegen.browser.min.js","lint":"gulp lint","release":"node tools/release.js","test":"gulp travis","unit-test":"gulp test"},"version":"1.14.1"};
+module.exports = {"_args":[["escodegen@1.14.1","/Users/gfrigerio/base/use-herald"]],"_from":"escodegen@1.14.1","_id":"escodegen@1.14.1","_inBundle":false,"_integrity":"sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==","_location":"/escodegen","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"escodegen@1.14.1","name":"escodegen","escapedName":"escodegen","rawSpec":"1.14.1","saveSpec":null,"fetchSpec":"1.14.1"},"_requiredBy":["/jsdom","/static-eval"],"_resolved":"https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz","_spec":"1.14.1","_where":"/Users/gfrigerio/base/use-herald","bin":{"esgenerate":"bin/esgenerate.js","escodegen":"bin/escodegen.js"},"bugs":{"url":"https://github.com/estools/escodegen/issues"},"dependencies":{"esprima":"^4.0.1","estraverse":"^4.2.0","esutils":"^2.0.2","optionator":"^0.8.1","source-map":"~0.6.1"},"description":"ECMAScript code generator","devDependencies":{"acorn":"^7.1.0","bluebird":"^3.4.7","bower-registry-client":"^1.0.0","chai":"^3.5.0","commonjs-everywhere":"^0.9.7","gulp":"^3.8.10","gulp-eslint":"^3.0.1","gulp-mocha":"^3.0.1","semver":"^5.1.0"},"engines":{"node":">=4.0"},"files":["LICENSE.BSD","README.md","bin","escodegen.js","package.json"],"homepage":"http://github.com/estools/escodegen","license":"BSD-2-Clause","main":"escodegen.js","maintainers":[{"name":"Yusuke Suzuki","email":"utatane.tea@gmail.com","url":"http://github.com/Constellation"}],"name":"escodegen","optionalDependencies":{"source-map":"~0.6.1"},"repository":{"type":"git","url":"git+ssh://git@github.com/estools/escodegen.git"},"scripts":{"build":"cjsify -a path: tools/entry-point.js > escodegen.browser.js","build-min":"cjsify -ma path: tools/entry-point.js > escodegen.browser.min.js","lint":"gulp lint","release":"node tools/release.js","test":"gulp travis","unit-test":"gulp test"},"version":"1.14.1"};
 
 /***/ }),
 

--- a/dist/src/assignees.d.ts
+++ b/dist/src/assignees.d.ts
@@ -1,3 +1,3 @@
 import { Octokit } from '@octokit/rest';
 import { MatchingRule } from './rules';
-export declare const handleAssignees: (client: InstanceType<typeof Octokit>, owner: string, repo: string, prNumber: number, matchingRules: MatchingRule[], requestConcurrency?: number) => Promise<import("@octokit/types").OctokitResponse<import("@octokit/types").IssuesAddAssigneesResponseData>[]>;
+export declare const handleAssignees: (client: InstanceType<typeof Octokit>, owner: string, repo: string, prNumber: number, matchingRules: MatchingRule[], requestConcurrency?: number) => Promise<unknown>;

--- a/dist/src/comment.d.ts
+++ b/dist/src/comment.d.ts
@@ -1,3 +1,3 @@
 import { MatchingRule } from './rules';
 import { Octokit } from '@octokit/rest';
-export declare const handleComment: (client: InstanceType<typeof Octokit>, owner: string, repo: string, prNumber: number, matchingRules: MatchingRule[], requestConcurrency?: number) => Promise<import("@octokit/types").OctokitResponse<import("@octokit/types").IssuesCreateCommentResponseData>[]>;
+export declare const handleComment: (client: InstanceType<typeof Octokit>, owner: string, repo: string, prNumber: number, matchingRules: MatchingRule[], requestConcurrency?: number) => Promise<unknown>;

--- a/dist/src/reviewers.d.ts
+++ b/dist/src/reviewers.d.ts
@@ -1,3 +1,3 @@
 import { Octokit } from '@octokit/rest';
 import { MatchingRule } from './rules';
-export declare const handleReviewers: (client: InstanceType<typeof Octokit>, owner: string, repo: string, prNumber: number, matchingRules: MatchingRule[], requestConcurrency?: number) => Promise<import("@octokit/types").OctokitResponse<import("@octokit/types").PullsRequestReviewersResponseData>[]>;
+export declare const handleReviewers: (client: InstanceType<typeof Octokit>, owner: string, repo: string, prNumber: number, matchingRules: MatchingRule[], requestConcurrency?: number) => Promise<unknown>;

--- a/dist/src/rules.d.ts
+++ b/dist/src/rules.d.ts
@@ -1,10 +1,5 @@
 import { Event } from './util/constants';
 import { RestEndpointMethodTypes } from '@octokit/rest';
-declare enum RuleMatchers {
-    includesInPatch = "includesInPatch",
-    eventJsonPath = "eventJsonPath",
-    includes = "includes"
-}
 export declare enum RuleActions {
     comment = "comment",
     review = "review",
@@ -30,7 +25,7 @@ export interface Rule {
 declare type File = RestEndpointMethodTypes['repos']['compareCommits']['response']['data']['files'][0];
 export declare const loadRules: (rulesLocation: string) => Rule[];
 export declare type MatchingRule = Rule & {
-    matches: Partial<Record<RuleMatchers | 'includeExclude', unknown[]>>;
+    matched: boolean;
 };
 export declare const allRequiredRulesHaveMatched: (rules: Rule[], matchingRules: MatchingRule[]) => boolean;
 export declare const getMatchingRules: (rules: Rule[], files: Partial<File> & Required<Pick<File, 'filename'>>[], event: Event, patchContent: string[]) => MatchingRule[];

--- a/src/assignees.ts
+++ b/src/assignees.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import { Octokit } from '@octokit/rest';
 import { MatchingRule } from './rules';
 import PQueue from 'p-queue';
@@ -13,7 +12,7 @@ export const handleAssignees = async (
   prNumber: number,
   matchingRules: MatchingRule[],
   requestConcurrency = 1
-) => {
+): Promise<unknown> => {
   const queue = new PQueue({ concurrency: requestConcurrency });
 
   debug('handleAssignees called with:', matchingRules);

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import PQueue from 'p-queue';
 
 import { composeCommentsForUsers, MatchingRule } from './rules';
@@ -45,7 +44,7 @@ export const handleComment = async (
   prNumber: number,
   matchingRules: MatchingRule[],
   requestConcurrency = 1
-) => {
+): Promise<unknown> => {
   debug('handleComment called with:', matchingRules);
 
   const queue = new PQueue({ concurrency: requestConcurrency });
@@ -57,9 +56,7 @@ export const handleComment = async (
   });
   const comments = rawComments.map(({ body }) => body);
 
-  const onlyNewComments = commentsFromRules.filter(
-    (comment: string) => !comments.includes(comment)
-  );
+  const onlyNewComments = commentsFromRules.filter((comment: string) => !comments.includes(comment));
 
   debug('comments to add:', onlyNewComments);
 

--- a/src/reviewers.ts
+++ b/src/reviewers.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import { Octokit } from '@octokit/rest';
 import PQueue from 'p-queue';
 
@@ -13,7 +12,7 @@ export const handleReviewers = async (
   prNumber: number,
   matchingRules: MatchingRule[],
   requestConcurrency = 1
-) => {
+): Promise<unknown> => {
   const queue = new PQueue({ concurrency: requestConcurrency });
 
   debug('handleReviewers called with:', matchingRules);
@@ -25,9 +24,7 @@ export const handleReviewers = async (
           repo,
           pull_number: prNumber,
           reviewers: matchingRule.users.map((user) => user.replace('@', '')),
-          team_reviewers: matchingRule.teams.map((team) =>
-            team.replace('@', '')
-          ),
+          team_reviewers: matchingRule.teams.map((team) => team.replace('@', '')),
         })
       )
     )

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -252,6 +252,8 @@ const isMatch: Matcher = (rule, options) => {
   const matches = keyMatchers
     .filter((matcher) => rule[matcher]?.length)
     .map((matcher) => matchers[matcher](rule, options));
+
+  debug('isMatch:', { rule, matches });
   return matches.length ? matches.every((match) => match === true) : false;
 };
 export const getMatchingRules = (

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -198,7 +198,7 @@ const handleIncludesInPatch: HandleIncludesInPatch = ({ patterns, patch }) => {
     }
   }, [] as string[]);
 
-  return !![...new Set(matches)].length;
+  return !!matches.length;
 };
 
 export const allRequiredRulesHaveMatched = (rules: Rule[], matchingRules: MatchingRule[]): boolean => {


### PR DESCRIPTION
<!--- IMPORTANT: Please do not create a Pull Request without [creating an issue first](https://github.com/gagoar/use-herald-action/issues/new) -->

<!--- write down the issue related to this  PR-->

**Issue Reference**: #84 
It also addresses #85 

## Description

- Simplifying how MatchingRules report results (moving the matching members to debug instead of storing them in the MatchingRule)
- Making multiple rules to be && instead of OR when combined in a single rule. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need to simplify how we match to make it more powerful. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Unit tests.  I've added 2 cases:  
1) When includes and eventJSONPath match -> match
2) When includes does not match but eventJSONPath match -> no match

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
