### PR TITLE
I should have waited for workflows to run :gun:

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -49,4 +49,7 @@ jobs:
         run: |
           npm install
       - name: Build
-        run: npm run build
+        run: npm run Build
+      - name: Check if build is different from the committed changes
+        run: |
+          git diff-index --quiet HEAD -- || exit 1

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -51,4 +51,4 @@ jobs:
       - name: build
         run: npm run build
       - name: check if build is different from the committed changes
-        run: git diff-index --quiet HEAD -- || exit 1
+        run: git diff-index --quiet HEAD -- dist/index.js || exit 1

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -50,9 +50,3 @@ jobs:
           npm install
       - name: build
         run: npm run build
-      - uses: actions/upload-artifact@master
-        with:
-          name: binary
-          path: dist/index.js
-      - name: check if build is different from the committed changes
-        run: git diff --exit-code --name-status dist/index.js

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -51,4 +51,4 @@ jobs:
       - name: build
         run: npm run build
       - name: check if build is different from the committed changes
-        run: git diff-index --quiet HEAD -- dist/index.js || exit 1
+        run: git diff --exit-code --name-status dist/index.js

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -50,5 +50,10 @@ jobs:
           npm install
       - name: build
         run: npm run build
+      - name: event location
+      - uses: actions/upload-artifact@master
+        with:
+          name: binary
+          path: dist/index.js
       - name: check if build is different from the committed changes
         run: git diff --exit-code --name-status dist/index.js

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -48,8 +48,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm install
-      - name: Build
-        run: npm run Build
-      - name: Check if build is different from the committed changes
-        run: |
-          git diff-index --quiet HEAD -- || exit 1
+      - name: build
+        run: npm run build
+      - name: check if build is different from the committed changes
+        run: git diff-index --quiet HEAD -- || exit 1

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -50,7 +50,6 @@ jobs:
           npm install
       - name: build
         run: npm run build
-      - name: event location
       - uses: actions/upload-artifact@master
         with:
           name: binary

--- a/dist/index.js
+++ b/dist/index.js
@@ -4226,7 +4226,7 @@ const handleIncludesInPatch = ({ patterns, patch }) => {
             return memo;
         }
     }, []);
-    return !![...new Set(matches)].length;
+    return !!(matches === null || matches === void 0 ? void 0 : matches.length);
 };
 const allRequiredRulesHaveMatched = (rules, matchingRules) => {
     const requiredRules = rules.filter((rule) => rule.errorLevel && rule.errorLevel === ErrorLevels.error);

--- a/herald_rules/add_assignee_for_workflows.json
+++ b/herald_rules/add_assignee_for_workflows.json
@@ -2,5 +2,5 @@
   "name": "This is a rule to add @gagoar as a assignee when workflow changes",
   "includes": ["src/*.ts"],
   "action": "assign",
-  "users": ["@gagoar"]
+  "users": ["gagoar"]
 }

--- a/herald_rules/add_comment_for_workflows.json
+++ b/herald_rules/add_comment_for_workflows.json
@@ -2,5 +2,5 @@
   "name": "This is a rule to attach @gagoar when workflow changes",
   "includes": [".github/workflows/*"],
   "action": "comment",
-  "users": ["@gagoar"]
+  "users": ["gagoar"]
 }

--- a/herald_rules/add_reviewer_for_workflows.json
+++ b/herald_rules/add_reviewer_for_workflows.json
@@ -2,5 +2,5 @@
   "name": "This is a rule to add @cyamonide as a reviewer when workflow changes",
   "includes": [".github/workflows/*"],
   "action": "review",
-  "users": ["@cyamonide"]
+  "users": ["cyamonide"]
 }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -198,7 +198,7 @@ const handleIncludesInPatch: HandleIncludesInPatch = ({ patterns, patch }) => {
     }
   }, [] as string[]);
 
-  return !!matches.length;
+  return !!matches?.length;
 };
 
 export const allRequiredRulesHaveMatched = (rules: Rule[], matchingRules: MatchingRule[]): boolean => {


### PR DESCRIPTION
<!--- IMPORTANT: Please do not create a Pull Request without [creating an issue first](https://github.com/gagoar/use-herald-action/issues/new) -->

## Description

I didn't wait for the workflow to finish the run, and I end up merging code that had errors. 
also:
- I've also fixed the rules we had given the change on #80 
- Adding a check so we always fail if dist/index.js is different from the one that we generate with npm run build on `validation` workflow. 

## Motivation and Context

Fix my own mistakes. 

## How Has This Been Tested?

npm run test. 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
