### PR TITLE
Add auto-changelog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1696,6 +1696,28 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "auto-changelog": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-2.2.0.tgz",
+      "integrity": "sha512-RBY0hhVNXstggOQL0SyUaCfSiVD11CVXEHvDwB+mEt9UnhXPqhdpQ7nIVGDEog7JopTdYbydULLLt6v//qrWjw==",
+      "dev": true,
+      "requires": {
+        "commander": "^5.0.0",
+        "handlebars": "^4.7.3",
+        "lodash.uniqby": "^4.7.0",
+        "node-fetch": "^2.6.0",
+        "parse-github-url": "^1.0.2",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -3386,6 +3408,19 @@
       "dev": true,
       "optional": true
     },
+    "handlebars": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -4806,6 +4841,12 @@
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
     },
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
+      "dev": true
+    },
     "log-symbols": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
@@ -5223,6 +5264,12 @@
         }
       }
     },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -5589,6 +5636,12 @@
       "requires": {
         "callsites": "^3.0.0"
       }
+    },
+    "parse-github-url": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
+      "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
+      "dev": true
     },
     "parse-json": {
       "version": "5.0.0",
@@ -8076,6 +8129,13 @@
       "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
       "dev": true
     },
+    "uglify-js": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.2.tgz",
+      "integrity": "sha512-GXCYNwqoo0MbLARghYjxVBxDCnU0tLqN7IPLdHHbibCb1NI5zBkU2EPcy/GaVxc0BtTjqyGXJCINe6JMR2Dpow==",
+      "dev": true,
+      "optional": true
+    },
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
@@ -8393,6 +8453,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "jest",
     "build": "ncc build index.ts",
     "lint": "eslint index.ts",
-    "version": "auto-changelog --issue-url https://github.com/gagoar/use-herald-action/issue/{id} --merge-url https://github.com/gagoar/use-herald/action/pull/{id} --compare-url https://github.com/gagoar/use-herald-action/compare/{from}...{to}"
+    "version": "auto-changelog -p --issue-url https://github.com/gagoar/use-herald-action/issue/{id} --merge-url https://github.com/gagoar/use-herald/action/pull/{id} --compare-url https://github.com/gagoar/use-herald-action/compare/{from}...{to} && git add CHANGELOG.md"
   },
   "engines": {
     "node": ">12.0.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "test": "jest",
     "build": "ncc build index.ts",
-    "lint": "eslint index.ts"
+    "lint": "eslint index.ts",
+    "version": "auto-changelog --issue-url https://github.com/gagoar/use-herald-action/issue/{id} --merge-url https://github.com/gagoar/use-herald/action/pull/{id} --compare-url https://github.com/gagoar/use-herald-action/compare/{from}...{to}"
   },
   "engines": {
     "node": ">12.0.0"
@@ -116,6 +117,7 @@
     "@typescript-eslint/parser": "3.9.1",
     "@zeit/ncc": "0.22.3",
     "ajv-keywords": "3.5.2",
+    "auto-changelog": "^2.2.0",
     "bufferutil": "4.0.1",
     "canvas": "2.6.1",
     "eslint": "7.7.0",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@typescript-eslint/parser": "3.9.1",
     "@zeit/ncc": "0.22.3",
     "ajv-keywords": "3.5.2",
-    "auto-changelog": "^2.2.0",
+    "auto-changelog": "2.2.0",
     "bufferutil": "4.0.1",
     "canvas": "2.6.1",
     "eslint": "7.7.0",


### PR DESCRIPTION
<!--- IMPORTANT: Please do not create a Pull Request without [creating an issue first](https://github.com/gagoar/use-herald-action/issues/new) -->

<!--- write down the issue related to this  PR-->

**Issue Reference**: closes #82 

## Description

<!--- Describe your changes in detail -->

This PR adds `auto-changelog` as a dev dependency, and sets up a pre-hook to `npm version`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Locally, I bumped the patch version, and the changelog was generated successfully.
I will not be committing the test changelog so that `v2.0`'s changelog doesn't get polluted.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
