### PR TITLE
Fix build-test Herald action to use checked in dist files

### DIFF
--- a/.github/workflows/use_action_for_build_test.yml
+++ b/.github/workflows/use_action_for_build_test.yml
@@ -12,10 +12,18 @@ jobs:
       - uses: actions/checkout@master
       - name: Install packages
         run: npm install
-      - name: Build binary
+      - name: Dry run Herald rules with checked in dist/
+        id: herald-dist
+        uses: ./
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          rulesLocation: herald_rules_for_build/*.json
+          DEBUG: '*'
+          dryRun: true
+      - name: Rebuild binary
         run: npm run build
-      - name: apply herald rules
-        id: herald
+      - name: Dry run Herald rules with rebuilt dist/
+        id: herald-rebuilt
         uses: ./
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--- IMPORTANT: Please do not create a Pull Request without [creating an issue first](https://github.com/gagoar/use-herald-action/issues/new) -->

<!--- write down the issue related to this  PR-->

## Description

<!--- Describe your changes in detail -->

This PR adds an additional dry run step which dry-runs the action using checked in `dist/` files.

The issues we were having with the `isPlainObject` dependency stemmed from the fact that checked in `dist/` files differed from `dist/` files that were outputted from rebuilding in the GH Actions environment. 

Previously, our build test action ran after building UHA, and succeeded. However, `pull_request_target` action used the checked in binary (which was incorrect), and thus kept on failing.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
