### PR TITLE
Remove node_modules path from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,9 +23,6 @@
     "resolveJsonModule": true,
     "experimentalDecorators": true,
     "baseUrl": "./",
-    "paths": {
-      "*": ["node_modules/*"]
-    },
     "jsx": "react",
     "esModuleInterop": true
   }


### PR DESCRIPTION

related to https://github.com/octokit/rest.js/issues/1929

## Description

<!--- Describe your changes in detail -->

This PR should resolve the `is-plain-object` dependency resolution issues we've been experiencing while trying to upgrade `@octokit/rest`: https://github.com/gagoar/use-herald-action/pull/247

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Will be testing by rebasing #247 and looking at PR checks.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
