### PR TITLE
making nvm version dictate workflow node version

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -7,10 +7,10 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@master
       - name: Read .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
         id: nvm
-      - uses: actions/checkout@master
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -7,11 +7,14 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     steps:
+      - name: Read .nvmrc
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        id: nvm
       - uses: actions/checkout@master
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: '${{ steps.nvm.outputs.NVMRC }}'
       - name: Install dependencies
         run: |
           npm install
@@ -26,7 +29,7 @@ jobs:
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: '${{ steps.nvm.outputs.NVMRC }}'
       - name: Install dependencies
         run: npm install
       - name: Jest

--- a/.github/workflows/validation_on_master.yml
+++ b/.github/workflows/validation_on_master.yml
@@ -9,11 +9,14 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     steps:
+      - name: Read .nvmrc
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        id: nvm
       - uses: actions/checkout@master
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: '${{ steps.nvm.outputs.NVMRC }}'
       - name: Install dependencies
         run: |
           npm install
@@ -27,7 +30,7 @@ jobs:
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: '${{ steps.nvm.outputs.NVMRC }}'
       - name: Install dependencies
         run: |
           npm install
@@ -50,7 +53,7 @@ jobs:
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: '${{ steps.nvm.outputs.NVMRC }}'
       - name: Install dependencies
         run: |
           npm install

--- a/.github/workflows/validation_on_master.yml
+++ b/.github/workflows/validation_on_master.yml
@@ -9,10 +9,10 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@master
       - name: Read .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
         id: nvm
-      - uses: actions/checkout@master
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
## Description
using .nvmrc file as `node-version`  in workflows
<!--- Describe your changes in detail -->

## Motivation and Context

As we updated `.nvmrc` automatically via `renovate` we end up with a whole in the workflows to make sure we are not breaking anything. this PR solves that using `.nvmrc` file to make `node-version` take the correct node version


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
this PR
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
