### PR TITLE
Fix organization app setup links

### DIFF
--- a/organization-app-flow/create.html
+++ b/organization-app-flow/create.html
@@ -65,7 +65,7 @@
   const manifestJSON = {
     name: `[${orgName}] Use Herald Action App`,
     url: 'https://gagoar.github.io/use-herald-action',
-    redirect_url: `https://gagoar.github.io/use-herald-action/token`,
+    redirect_url: `https://gagoar.github.io/use-herald-action/organization-app-flow/token`,
     public: true,
     default_permissions: {
       ...repo_permissions,

--- a/organization-app-flow/index.html
+++ b/organization-app-flow/index.html
@@ -155,7 +155,7 @@
       <div class="container step-content">
         <form
           id="manifest-form"
-          action="https://gagoar.github.io/use-herald-action/create"
+          action="https://gagoar.github.io/use-herald-action/organization-app-flow/create"
           method="GET"
           target="_blank"
         >


### PR DESCRIPTION
<!--- IMPORTANT: Please do not create a Pull Request without [creating an issue first](https://github.com/gagoar/use-herald-action/issues/new) -->

<!--- write down the issue related to this  PR-->

**Issue Reference**: closes #409 

## Description

<!--- Describe your changes in detail -->

In #359 we changed the the organization app setup links, which caused links on the pages themselves to break.

This PR updates those broken links.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
