### PR TITLE
Execute status rule if every rule fails

### DIFF
--- a/__mocks__/rules/rule3.json
+++ b/__mocks__/rules/rule3.json
@@ -1,0 +1,9 @@
+{
+    "name": "bot validation",
+    "description": "bot validation",
+    "action": "status",
+    "eventJsonPath": [
+        "$[?(@.type.match(/bot/i))]"
+    ],
+    "targetURL": "https://github.com/gagoar/use-herald-action/wiki"
+}

--- a/__mocks__/rules/rule3.json
+++ b/__mocks__/rules/rule3.json
@@ -1,9 +1,7 @@
 {
-    "name": "bot validation",
-    "description": "bot validation",
-    "action": "status",
-    "eventJsonPath": [
-        "$[?(@.type.match(/bot/i))]"
-    ],
-    "targetURL": "https://github.com/gagoar/use-herald-action/wiki"
+  "name": "bot validation",
+  "description": "bot validation",
+  "action": "status",
+  "eventJsonPath": ["$[?(@.type.match(/bot/i))]"],
+  "targetURL": "https://github.com/gagoar/use-herald-action/wiki"
 }

--- a/__tests__/index.HttpFailure.spec.ts
+++ b/__tests__/index.HttpFailure.spec.ts
@@ -56,7 +56,7 @@ describe('use-herald', () => {
       .reply(200, getCommentsResponse);
 
     github
-      .post(`/repos/${login}/${name}/issues/2/comments`)
+      .post(`/repos/${login}/${name}/statuses/${head.sha}`)
       .replyWithError({ message: 'Resource not accessible by integration', code: HttpErrors.RESOURCE_NOT_ACCESSIBLE });
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -65,11 +65,10 @@ describe('use-herald', () => {
     await main();
 
     expect(setOutput).not.toHaveBeenCalled();
-
     expect(setFailed.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
-          "request to https://api.github.com/repos/gagoar/example_repo/issues/2/comments failed, reason: Resource not accessible by integration",
+          "request to https://api.github.com/repos/gagoar/example_repo/statuses/ec26c3e57ca3a959ca5aad62de7213c562f8c821 failed, reason: Resource not accessible by integration",
         ],
       ]
     `);

--- a/__tests__/index.HttpFailure.spec.ts
+++ b/__tests__/index.HttpFailure.spec.ts
@@ -55,9 +55,14 @@ describe('use-herald', () => {
       .get(`/repos/${login}/${name}/issues/${prIssue}/comments?page=1&per_page=100`)
       .reply(200, getCommentsResponse);
 
+
+    github
+      .post(`/repos/${login}/${name}/issues/2/comments`)
+      .replyWithError({ message: 'Resource not accessible by integration', code: HttpErrors.RESOURCE_NOT_ACCESSIBLE });
+
     github
       .post(`/repos/${login}/${name}/statuses/${head.sha}`)
-      .replyWithError({ message: 'Resource not accessible by integration', code: HttpErrors.RESOURCE_NOT_ACCESSIBLE });
+      .reply(201)
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { main } = require('../src') as Main;
@@ -68,7 +73,7 @@ describe('use-herald', () => {
     expect(setFailed.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
-          "request to https://api.github.com/repos/gagoar/example_repo/statuses/ec26c3e57ca3a959ca5aad62de7213c562f8c821 failed, reason: Resource not accessible by integration",
+          "request to https://api.github.com/repos/gagoar/example_repo/issues/2/comments failed, reason: Resource not accessible by integration",
         ],
       ]
     `);

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -37,6 +37,10 @@ const getGithubMock = () =>
   });
 
 describe('use-herald-action', () => {
+  const owner = 'gagoar';
+  const repo = 'example_repo';
+  const sha = 'ec26c3e57ca3a959ca5aad62de7213c562f8c821';
+
   beforeEach(() => {
     getInput.mockClear();
     setFailed.mockClear();
@@ -83,6 +87,10 @@ describe('use-herald-action', () => {
 
     const github = getGithubMock();
 
+    github
+    .post(`/repos/${owner}/${repo}/statuses/${sha}`)
+    .reply(201, {})
+
     const { main } = require('../src') as Main;
 
     await main();
@@ -99,6 +107,10 @@ describe('use-herald-action', () => {
     });
 
     const github = getGithubMock();
+    
+    github
+    .post(`/repos/${owner}/${repo}/statuses/${sha}`)
+    .reply(201, {})
 
     const { main } = require('../src') as Main;
 
@@ -129,6 +141,22 @@ describe('use-herald-action', () => {
                 "miny",
                 "moe",
               ],
+            },
+            Object {
+              "action": "status",
+              "description": "bot validation",
+              "eventJsonPath": Array [
+                "$[?(@.type.match(/bot/i))]",
+              ],
+              "excludes": Array [],
+              "includes": Array [],
+              "includesInPatch": Array [],
+              "matched": false,
+              "name": "bot validation",
+              "path": "${env.GITHUB_WORKSPACE}/__mocks__/rules/rule3.json",
+              "targetURL": "https://github.com/gagoar/use-herald-action/wiki",
+              "teams": Array [],
+              "users": Array [],
             },
           ],
         ],

--- a/dist/index.js
+++ b/dist/index.js
@@ -22734,7 +22734,6 @@ var main = async () => {
             if (!rulesForAction.length) {
               return promises;
             }
-            console.log(actionName);
             const options = {
               owner,
               repo,

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,6 @@ export const main = async (): Promise<void> => {
               if (!rulesForAction.length) {
                 return promises;
               }
-              console.log(actionName)
               const options: ActionInput = {
                 owner,
                 repo,

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,7 @@ export const main = async (): Promise<void> => {
               if (!rulesForAction.length) {
                 return promises;
               }
-
+              console.log(actionName)
               const options: ActionInput = {
                 owner,
                 repo,

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -268,7 +268,7 @@ class MatchingRules extends Array<MatchingRule> {
 
     const matchedRules = await Promise.all(matchingRules);
 
-    const filtered = matchedRules.filter((rule) => isMatchingRule(rule) && rule.matched);
+    const filtered = matchedRules.filter((rule) => isMatchingRule(rule) && rule.matched || rule.action === RuleActions.status);
 
     return new MatchingRules(...filtered);
   }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -269,10 +269,10 @@ class MatchingRules extends Array<MatchingRule> {
     const matchedRules = await Promise.all(matchingRules);
 
     // status for now is the only type of rule that should always match given that it has an action regardless of the outcome.
-    const alwaysMatchRuleType = [RuleActions.status]
+    const mandatoryRulesTypes = [RuleActions.status]
 
     const filtered = matchedRules.filter((rule) =>
-      alwaysMatchRuleType.includes(rule.action as RuleActions) || isMatchingRule(rule) && rule.matched);
+      mandatoryRulesTypes.includes(rule.action as RuleActions) || isMatchingRule(rule) && rule.matched);
     return new MatchingRules(...filtered);
   }
 }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -272,7 +272,6 @@ class MatchingRules extends Array<MatchingRule> {
 
     const filtered = matchedRules.filter((rule) =>
       alwaysMatchedRulesTypes.includes(rule.action as RuleActions) || isMatchingRule(rule) && rule.matched);
-    console.log({ filtered })
     return new MatchingRules(...filtered);
   }
 }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -268,8 +268,11 @@ class MatchingRules extends Array<MatchingRule> {
 
     const matchedRules = await Promise.all(matchingRules);
 
-    const filtered = matchedRules.filter((rule) => isMatchingRule(rule) && rule.matched || rule.action === RuleActions.status);
+    const alwaysMatchedRulesTypes = [RuleActions.status]
 
+    const filtered = matchedRules.filter((rule) =>
+      alwaysMatchedRulesTypes.includes(rule.action as RuleActions) || isMatchingRule(rule) && rule.matched);
+    console.log({ filtered })
     return new MatchingRules(...filtered);
   }
 }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -268,10 +268,11 @@ class MatchingRules extends Array<MatchingRule> {
 
     const matchedRules = await Promise.all(matchingRules);
 
-    const alwaysMatchedRulesTypes = [RuleActions.status]
+    // status for now is the only type of rule that should always match given that it has an action regardless of the outcome.
+    const alwaysMatchRuleType = [RuleActions.status]
 
     const filtered = matchedRules.filter((rule) =>
-      alwaysMatchedRulesTypes.includes(rule.action as RuleActions) || isMatchingRule(rule) && rule.matched);
+      alwaysMatchRuleType.includes(rule.action as RuleActions) || isMatchingRule(rule) && rule.matched);
     return new MatchingRules(...filtered);
   }
 }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -269,10 +269,10 @@ class MatchingRules extends Array<MatchingRule> {
     const matchedRules = await Promise.all(matchingRules);
 
     // status for now is the only type of rule that should always match given that it has an action regardless of the outcome.
-    const mandatoryRulesTypes = [RuleActions.status]
+    const mandatoryRuleTypes = [RuleActions.status]
 
     const filtered = matchedRules.filter((rule) =>
-      mandatoryRulesTypes.includes(rule.action as RuleActions) || isMatchingRule(rule) && rule.matched);
+      mandatoryRuleTypes.includes(rule.action as RuleActions) || isMatchingRule(rule) && rule.matched);
     return new MatchingRules(...filtered);
   }
 }

--- a/src/statuses.ts
+++ b/src/statuses.ts
@@ -29,7 +29,7 @@ export const handleStatus: ActionMapInput = async (
     context: `Herald › ${rule.name}`,
     description: rule.description ? rule.description : STATUS_DESCRIPTION_COPY,
     target_url: rule.targetURL ? rule.targetURL : getBlobURL(rule.path, files, owner, repo, base),
-    state: matchingRules.find((matchingRule) => matchingRule.path === rule.path)
+    state: matchingRules.find((matchingRule) => matchingRule.path === rule.path)?.matched
       ? CommitStatus.SUCCESS
       : CommitStatus.FAILURE,
   }));


### PR DESCRIPTION
<!--- IMPORTANT: Please do not create a Pull Request without [creating an issue first](https://github.com/gagoar/use-herald-action/issues/new) -->

<!--- write down the issue related to this  PR-->

**Issue Reference**:[#530](https://github.com/gagoar/use-herald-action/issues/530)

## Description
i updated the getMatchingRules method to return all the status rules and also the validation to update the status to be success or failure depending on the match result and not if it exists on the Matching rules
<!--- Describe your changes in detail -->

## Motivation and Context
it fixes this [Issue 530](https://github.com/gagoar/use-herald-action/issues/530)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
i've tested it on my private repo where i have just one status rule
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
