### PR TITLE
Bump codeclimate-action to v9 to fix checksum verification failure

### DIFF
--- a/.github/workflows/validation_on_master.yml
+++ b/.github/workflows/validation_on_master.yml
@@ -42,7 +42,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
       - name: Publish code coverage to Code Climate
-        uses: paambaati/codeclimate-action@v3.0.0
+        uses: paambaati/codeclimate-action@v9
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}
   build:


### PR DESCRIPTION
## Description

Bumps `paambaati/codeclimate-action` from `v3.0.0` to `v9` in `.github/workflows/validation_on_master.yml`.

## Motivation and Context

`validation on Master` has been failing on every push at the "Publish code coverage to Code Climate" step:

```
Error: CC Reporter checksum does not match!
```

`v3.0.0` of the action bundles a hardcoded checksum for the `cc-test-reporter` binary it downloads from Code Climate's CDN. That binary has since been rotated upstream, so the checksum baked into the old action version no longer matches — unrelated to any code change in this repo, jest/lint/build all pass on the same commit. `v9` verifies the downloaded binary dynamically (`verifyDownload` input, default `true`) rather than against a value hardcoded at release time, so it isn't affected by this kind of upstream drift. The `CC_TEST_REPORTER_ID` env var usage is unchanged between versions.

## How Has This Been Tested?

Single-line workflow YAML change (version bump only). Will be validated by CI running on this PR — the `test` job in `validation on Master` doesn't run on `pull_request` events though, so this needs a push to `master` to confirm the fix; `validation.yml` (PR-triggered) doesn't include the Code Climate step at all.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.