### PR TITLE
Migrate coverage upload from Code Climate to Qlty Cloud

### DIFF
--- a/.github/workflows/validation_on_master.yml
+++ b/.github/workflows/validation_on_master.yml
@@ -41,10 +41,11 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
-      - name: Publish code coverage to Code Climate
-        uses: paambaati/codeclimate-action@v9
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}
+      - name: Publish code coverage to Qlty Cloud
+        uses: qltysh/qlty-action/coverage@v2
+        with:
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          files: coverage/lcov.info
   build:
     name: Run build
     runs-on: ubuntu-latest

--- a/.github/workflows/validation_on_master.yml
+++ b/.github/workflows/validation_on_master.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Jest
         run: npm run test --coverage
       - name: Send coverage to codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
       - name: Publish code coverage to Qlty Cloud
-        uses: qltysh/qlty-action/coverage@v2
+        uses: qltysh/qlty-action/coverage@08a0a862c159eae9b9003081da6663d96efef637 # v2
         with:
           token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
           files: coverage/lcov.info


### PR DESCRIPTION
## Description

Replaces the "Publish code coverage to Code Climate" step in `validation_on_master.yml` with Qlty Cloud's official coverage action (`qltysh/qlty-action/coverage@v2`), uploading the same `coverage/lcov.info` Jest already produces.

## Motivation and Context

Follow-up to #552. That PR bumped `paambaati/codeclimate-action` to `v9` to fix a checksum mismatch, but the build kept failing afterward with a `404` downloading `test-reporter-latest-linux-amd64` from `codeclimate.com`.

Root cause: Code Climate Quality was fully decommissioned and replaced by **Qlty Cloud** (qlty.sh). Their legacy API/download endpoints stopped being served as of 2025-07-18 — confirmed in [`paambaati/codeclimate-action#802`](https://github.com/paambaati/codeclimate-action/issues/802), where the maintainer confirms no action version can work anymore and recommends migrating to Qlty's own action. `codeclimate/test-reporter` itself is archived (moved to `qltysh-archive/test-reporter`).

`qltysh/qlty-action/coverage@v2` just uploads an existing coverage report — no reporter binary download, so it isn't exposed to this class of failure.

## How Has This Been Tested?

Workflow YAML change only, following Qlty's documented migration guide (https://docs.qlty.sh/migration/coverage). Will be validated by a push to `master` after merge (this workflow doesn't trigger on `pull_request`, same caveat as #552).

**Action required after merge**: this repo needs a Qlty Cloud account/project connected, with a coverage token added as the `QLTY_COVERAGE_TOKEN` repo secret. Until that secret exists, the step will report a failed upload but **won't fail the build** — `skip-errors` defaults to `true` in this action.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.