### PR TITLE
Pin third-party actions to commit SHAs, add SRI to docs assets

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: auth
-        uses: jnwng/github-app-installation-token-action@v2
+        uses: jnwng/github-app-installation-token-action@c54add4c02866dc41e106745ac6dcf5cdd6339e5 # v2
         with:
           appId: ${{ secrets.UHA_APP_ID }}
           installationId: ${{ secrets.UHA_INSTALLATION_ID }}
@@ -38,7 +38,7 @@ jobs:
           git commit -m "rebuild dist/" -a
       - name: Push changes
         if: contains(steps.gitStatus.outputs.status, 'modified')
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master, no newer tagged release
         with:
           github_token: ${{ steps.auth.outputs.token }}
           branch: ${{ github.ref }}

--- a/.github/workflows/use_herald.yml
+++ b/.github/workflows/use_herald.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: auth
-        uses: jnwng/github-app-installation-token-action@v2
+        uses: jnwng/github-app-installation-token-action@c54add4c02866dc41e106745ac6dcf5cdd6339e5 # v2
         with:
           appId: ${{ secrets.UHA_APP_ID }}
           installationId: ${{ secrets.UHA_INSTALLATION_ID }}
@@ -19,7 +19,7 @@ jobs:
       - name: Install packages
         run: npm install
       - id: herald
-        uses: gagoar/use-herald-action@master
+        uses: ./
         with:
           GITHUB_TOKEN: ${{ steps.auth.outputs.token }}
           rulesLocation: herald_rules/*.json

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Jest
         run: npm run test --coverage
       - name: Send coverage to codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests

--- a/index.html
+++ b/index.html
@@ -9,7 +9,12 @@
       content="Documentation for use-herald-action - add comments, reviewers and assignees to a pull request depending on rules you define!"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/docsify@4.13.1/lib/themes/vue.css"
+      integrity="sha384-jCK82M2ExfkqAO/MYBKMjP1qC4AvZ4/Duf2gVWOy3RPn26uz+KW5I+9S39za1Fqv"
+      crossorigin="anonymous"
+    />
   </head>
   <body>
     <div id="app"></div>
@@ -20,6 +25,10 @@
       };
     </script>
     <!-- Docsify v4 -->
-    <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/docsify@4.13.1"
+      integrity="sha384-KaHhgnx/OTLoJ4J33SSJsF4x1pk4I7q3s5ZOfIDHJYl6IG7Oyn2vNDsHiWJe46fD"
+      crossorigin="anonymous"
+    ></script>
   </body>
 </html>


### PR DESCRIPTION
## Description

Fixes 6 of the 8 open code-scanning findings on this repo (the other 2, in `validation_on_master.yml`, are fixed in #553):

- **`githubactions:S7637`** — external GitHub Actions/workflows should be pinned to a commit hash:
  - `jnwng/github-app-installation-token-action@v2` → pinned SHA, in both `renovate.yml` and `use_herald.yml`
  - `ad-m/github-push-action@master` → pinned to master's current HEAD SHA (`renovate.yml`; no newer tagged release exists)
  - `codecov/codecov-action@v2` → pinned SHA (`validation.yml`)
  - `gagoar/use-herald-action@master` (`use_herald.yml`) → changed to `uses: ./` instead of a SHA pin. That workflow's whole purpose is to dogfood whatever is currently on `master` against incoming PRs; pinning it to a SHA would go stale the moment `master` advances and defeat the point. `uses: ./` runs whatever was checked out at that ref (already `master`, via the preceding `actions/checkout@master` with no `ref:` override) without treating it as an external, unpinned dependency.
- **`Web:S5725`** — remote artifacts should not be used without integrity checks:
  - `index.html`'s two jsDelivr-hosted docsify assets (CSS theme + script) lacked `integrity`/`crossorigin`. Since SRI hashes are tied to exact file bytes, pinned the floating `@4` version to the latest concrete 4.x release (`4.13.1`) and added `integrity` (sha384, computed from the actual served bytes) + `crossorigin="anonymous"`.

## Motivation and Context

GitHub's code-scanning (Sonar rules surfaced via SARIF) flagged 8 open warnings. These are supply-chain hardening findings — pinning to a commit hash prevents a compromised/rewritten upstream tag from silently changing what code runs in CI.

## How Has This Been Tested?

Workflow YAML and static HTML changes only; no application logic touched. SRI hashes were computed directly from the exact bytes served at the pinned CDN URLs (`openssl dgst -sha384`), not copied from an untrusted third party. Each SHA was resolved from the actual tag ref via the GitHub API, not guessed.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.